### PR TITLE
$LAB.in -- set working dir

### DIFF
--- a/LAB.src.js
+++ b/LAB.src.js
@@ -251,7 +251,7 @@
 			}
 			return sargs;
 		}
-				
+		
 		publicAPI = {
 			script:function() {
 				fCLEARTIMEOUT(end_of_chain_check_interval);
@@ -299,6 +299,22 @@
 				if (queueExec && !scripts_loading) exec.push(fn);
 				else queueAndExecute(fn);
 				return e;
+			},
+			in:function(dir, append) {
+			   if (!dir)
+			      dir = '';
+			   else if (dir && !/\/$/.test(dir))
+			      dir += "/";
+			    
+			   if (append) {
+			      _base_path+= dir;
+			      opts.base+= dir;
+			   } else {
+      			_base_path = dir;
+      			opts.base = dir;
+      		}
+      		
+			   return publicAPI;
 			}
 		};
 		if (queueExec) {
@@ -343,6 +359,9 @@
 		},
 		wait:function(){ // will ensure that the chain's previous scripts are executed before execution of scripts in subsequent chain links
 			return engine().wait.apply(nNULL,arguments);
+		},
+		in:function(){
+		   return engine().in.apply(nNULL,arguments);
 		}
 	};
 	

--- a/tests/1.js
+++ b/tests/1.js
@@ -1,0 +1,1 @@
+console.log("./1");

--- a/tests/a/1.js
+++ b/tests/a/1.js
@@ -1,0 +1,1 @@
+console.log("a/1");

--- a/tests/a/2.js
+++ b/tests/a/2.js
@@ -1,0 +1,1 @@
+console.log("a/2");

--- a/tests/a/3.js
+++ b/tests/a/3.js
@@ -1,0 +1,1 @@
+console.log("a/3");

--- a/tests/a/sub/1.js
+++ b/tests/a/sub/1.js
@@ -1,0 +1,1 @@
+console.log("a/sub/1");

--- a/tests/b/1.js
+++ b/tests/b/1.js
@@ -1,0 +1,1 @@
+console.log("b/1");

--- a/tests/c/1.js
+++ b/tests/c/1.js
@@ -1,0 +1,1 @@
+console.log("c/1");

--- a/tests/c/2.js
+++ b/tests/c/2.js
@@ -1,0 +1,1 @@
+console.log("c/2");

--- a/tests/test-1.html
+++ b/tests/test-1.html
@@ -1,10 +1,23 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="LAB.src.js"></script>
+<script src="../LAB.src.js"></script>
 </head>
 <body>
 <script>
-$LAB.script("test1script.php");
+$LAB
+	.in("a")
+		.script("1.js")
+		.script("2.js").wait()
+		.script("3.js")
+		.in("sub", true)
+			.script("1.js")
+	.in()
+		.script("1.js")
+	.in("b")
+		.script("1.js").wait()
+	.in("c")
+		.script("1.js")
+		.script("2.js");
 </script>
 </html>


### PR DESCRIPTION
Added in function to public api for specifying working dir for subsequent script loads. I couldn't see a good way to do this in the docs, so I made it. You can see a working example in tests/test-1.html.

Brief documentation:

``` javascript
$LAB.in( dir, [ append = false ] )
```
