### PR TITLE
Patch to allow setting .text attribute on generated script elements

### DIFF
--- a/LAB.src.js
+++ b/LAB.src.js
@@ -129,6 +129,7 @@
 			script = document.createElement("script");
 			if (script_obj.type) script.type = script_obj.type;
 			if (script_obj.charset) script.charset = script_obj.charset;
+			if (script_obj.text) script.text = script_obj.text;
 			
 			// should preloading be used for this script?
 			if (preload_this_script) {
@@ -227,6 +228,8 @@
 			script = registry_item.elem || document.createElement("script");
 			if (script_obj.type) script.type = script_obj.type;
 			if (script_obj.charset) script.charset = script_obj.charset;
+			if (script_obj.text) script.text = script_obj.text;
+
 			create_script_load_listener(script,registry_item,"finished",preload_execute_finished);
 			
 			// script elem was real-preloaded


### PR DESCRIPTION
It turns out that the body of external script tags sometimes matters.  (For example the google plusone API allows one to set parameters in the body of the external script tag.  See http://code.google.com/apis/+1button/#example-explicit-load and http://code.google.com/apis/+1button/#script-parameters for more on that.)

Anyhow, with this trivial patch, one can now do something like this to get a deferred explicit plusone button:

``` javascript
(function () {
    var script = {
        'src': "https://apis.google.com/js/plusone.js",
        'text': "{parsetags: 'explicit'}"
    };
    var callback = function () {
        gapi.plusone.render.apply('target-id', {size: 'medium'});
    };
    $LAB.script(script).wait(callback);
})();
```
