### PR TITLE
Added the ability to provide an id to the .script() parameters (for use in embedded jQuery templates)

### DIFF
--- a/LAB.src.js
+++ b/LAB.src.js
@@ -129,6 +129,7 @@
 			script = document.createElement("script");
 			if (script_obj.type) script.type = script_obj.type;
 			if (script_obj.charset) script.charset = script_obj.charset;
+			if (script_obj.id) script.id = script_obj.id; // useful if you need to name your scripts
 			
 			// should preloading be used for this script?
 			if (preload_this_script) {


### PR DESCRIPTION
Kyle, 

I am a fan of the jQuery Template and KnockoutJS libraries and since the template fragments are typically embedded in script tags but with a text/html content type like so:
 <script id="myTemplate"   type="text/html" src="./views/_mytemplate.view.html"></script>   

I had written a custom JS snippet to load all my templates. But since I have discovered LAB.js, I realized I could load these templates also. The only missing piece was that I (or KnockoutJS) needed to be able to find the template by id. 
So I have done a slight addition to ensure I could pass the id like so:
  $LAB.script({ src: "./views/_mytemplate.view.html", id: "myTemplate", type:"text/html" })

Let me know if it would be ok to integrate this in the base.

Philippe (@techarch)

PS: Thanks again for the great library! :-)
