### PR TITLE
Support for script ID attribute

### DIFF
--- a/LAB.src.js
+++ b/LAB.src.js
@@ -129,6 +129,7 @@
 			script = document.createElement("script");
 			if (script_obj.type) script.type = script_obj.type;
 			if (script_obj.charset) script.charset = script_obj.charset;
+			if (script_obj.id) script.id = script_obj.id;
 			
 			// should preloading be used for this script?
 			if (preload_this_script) {
@@ -226,6 +227,7 @@
 			script = registry_item.elem || document.createElement("script");
 			if (script_obj.type) script.type = script_obj.type;
 			if (script_obj.charset) script.charset = script_obj.charset;
+			if (script_obj.id) script.id = script_obj.id;
 			create_script_load_listener(script,registry_item,"finished",preload_execute_finished);
 			
 			// script elem was real-preloaded


### PR DESCRIPTION
Please check the changes... is this right way to do that.

support for script ID attribute same as charset

<script src="framework.js" id="marketing"></script>

(optional) the id attribute (ie, "marketing", etc)
